### PR TITLE
Fixed Local Default

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -186,9 +186,9 @@ function replace_default(content, sym;
         nbviewer_root_url = "https://nbviewer.jupyter.org/urls/$(base_url)"
         push!(repls, "@__NBVIEWER_ROOT_URL__" => nbviewer_root_url)
     else
-        push!(repls, "@__REPO_ROOT_URL__" => get(config, "repo_root_url", "<unknown>"))
-        push!(repls, "@__NBVIEWER_ROOT_URL__" => get(config, "nbviewer_root_url", "<unknown>"))
-        push!(repls, "@__BINDER_ROOT_URL__" => get(config, "binder_root_url", "<unknown>"))
+        push!(repls, "@__REPO_ROOT_URL__" => get(config, "repo_root_url", pwd()))
+        push!(repls, "@__NBVIEWER_ROOT_URL__" => get(config, "nbviewer_root_url", pwd()))
+        push!(repls, "@__BINDER_ROOT_URL__" => get(config, "binder_root_url", pwd()))
     end
 
     # run some Documenter specific things


### PR DESCRIPTION
The default path created for the meta block at the top of the literate markdown files did not compile without error when using Documenter. Instead of having an `<unknown>` tag placed, the modification returns `pwd()` which is consistent with the source when running locally and allows for offline document compilation.